### PR TITLE
Refactor health module registration in IoC container

### DIFF
--- a/src/api/v1/modules/health/health.module.ts
+++ b/src/api/v1/modules/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Container } from "inversify";
+import { TYPES } from "../../../../core/types/types.js";
+import { PingService } from "./ping.service.js";
+
+export const HealthModule = {
+  register(container: Container) {
+    container.bind(TYPES.PingService).to(PingService).inSingletonScope();
+  },
+};

--- a/src/api/v1/modules/health/index.ts
+++ b/src/api/v1/modules/health/index.ts
@@ -1,5 +1,6 @@
 import healthRouter from "./ping.routes.js";
 import { PingController } from "./ping.controller.js";
 import { PingService } from "./ping.service.js";
+import { HealthModule } from "./health.module.js";
 
-export { healthRouter, PingController, PingService };
+export { healthRouter, PingController, PingService, HealthModule };

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -1,15 +1,10 @@
 import { Container } from "inversify";
-import { TYPES } from "./types/types.js";
-import { IPingService } from "../api/v1/modules/health/ping.service.interface.js";
-import { PingService } from "../api/v1/modules/health/ping.service.js";
+import { HealthModule } from "../api/v1/modules/health/index.js";
 
 // Setup of IOC container
 const container = new Container();
 
-// Registration of classes
-container
-  .bind<IPingService>(TYPES.PingService)
-  .to(PingService)
-  .inSingletonScope();
+// Registration of classes per module
+HealthModule.register(container);
 
 export { container };


### PR DESCRIPTION
Introduced HealthModule with a register method to encapsulate dependency bindings for the health module. Updated the IoC container setup to use HealthModule for registration, improving modularity and maintainability.